### PR TITLE
Handle millisecond for time-format

### DIFF
--- a/src/main/java/com/treasure_data/td_import/prepare/Strftime.java
+++ b/src/main/java/com/treasure_data/td_import/prepare/Strftime.java
@@ -53,7 +53,7 @@ public class Strftime {
         translate.put("j", "DDD");
         translate.put("k", "HH"); // will show as '07' instead of ' 7'
         translate.put("l", "hh"); //will show as '07' instead of ' 7'
-        translate.put("L", "S");
+        translate.put("L", "SSS");
         translate.put("m", "MM");
         translate.put("M", "mm");
         translate.put("n", "\n");

--- a/src/test/java/com/treasure_data/td_import/prepare/TestStrftime.java
+++ b/src/test/java/com/treasure_data/td_import/prepare/TestStrftime.java
@@ -1,0 +1,34 @@
+package com.treasure_data.td_import.prepare;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Calendar;
+import java.util.TimeZone;
+
+import org.junit.Test;
+
+public class TestStrftime {
+    private Strftime t;
+
+    @Test
+    public void testMillisecond() {
+        t = new Strftime("%Y-%m-%d %H:%M:%S%z");
+        assertEquals(1427342681L, t.getTime("2015-03-26 04:04:41+0000"));
+
+        t = new Strftime("%Y-%m-%d %H:%M:%S.483647%z");
+        assertEquals(1427342681L, t.getTime("2015-03-26 04:04:41.483647+0000"));
+
+        t = new Strftime("%Y-%m-%d %H:%M:%S.483%z");
+        assertEquals(1427342681L, t.getTime("2015-03-26 04:04:41.483+0000"));
+
+        t = new Strftime("%Y-%m-%d %H:%M:%S.%L%z");
+        assertEquals(1427342681L, t.getTime("2015-03-26 04:04:41.483+0000"));
+
+        // Timezone free test
+        Calendar c = Calendar.getInstance();
+        c.set(2015, 2, 26, 4, 4, 41);
+        c.setTimeZone(TimeZone.getDefault());
+        t = new Strftime("%Y-%m-%d %H:%M:%S");
+        assertEquals(c.getTimeInMillis() / 1000, t.getTime("2015-03-26 04:04:41.483647"));
+    }
+}


### PR DESCRIPTION
Millisecond here is 3 digits subsecond representation. Current strftime
implementation does not support digits != 3 subsecond representation.