### PR TITLE
 Upgraded version of MessagePack to 0.8.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
   <properties>
     <!--  version properties for dependencies -->
     <jopt-simple.version>4.5</jopt-simple.version>
-    <msgpack.version>0.6.7</msgpack.version>
+    <msgpack.version>0.8.16</msgpack.version>
     <super-csv.version>2.1.0</super-csv.version>
     <td-client.version>0.5.5</td-client.version>
     <aws-java-sdk.version>1.7.5</aws-java-sdk.version>
@@ -100,7 +100,7 @@
     </dependency>
     <dependency>
       <groupId>org.msgpack</groupId>
-      <artifactId>msgpack</artifactId>
+      <artifactId>msgpack-core</artifactId>
       <version>${msgpack.version}</version>
     </dependency>
     <dependency>

--- a/src/test/java/com/treasure_data/td_import/integration/ApacheFileGenerator.java
+++ b/src/test/java/com/treasure_data/td_import/integration/ApacheFileGenerator.java
@@ -6,19 +6,19 @@ import java.util.Date;
 import java.util.Map;
 
 import org.junit.Ignore;
-import org.msgpack.type.Value;
-import org.msgpack.type.ValueFactory;
+import org.msgpack.value.Value;
+import org.msgpack.value.ValueFactory;
 
 @Ignore
 public class ApacheFileGenerator extends FileGenerator {
     private static final SimpleDateFormat dateFormat = new SimpleDateFormat("dd/MMM/yyyy:HH:mm:ss Z");
 
-    static Value HOST_VALUE = ValueFactory.createRawValue("host");
-    static Value USER_VALUE = ValueFactory.createRawValue("user");
-    static Value METHOD_VALUE = ValueFactory.createRawValue("method");
-    static Value PATH_VALUE = ValueFactory.createRawValue("path");
-    static Value CODE_VALUE = ValueFactory.createRawValue("code");
-    static Value SIZE_VALUE = ValueFactory.createRawValue("size");
+    static Value HOST_VALUE = ValueFactory.newString("host");
+    static Value USER_VALUE = ValueFactory.newString("user");
+    static Value METHOD_VALUE = ValueFactory.newString("method");
+    static Value PATH_VALUE = ValueFactory.newString("path");
+    static Value CODE_VALUE = ValueFactory.newString("code");
+    static Value SIZE_VALUE = ValueFactory.newString("size");
 
     protected static final String SPACE = " ";
     protected static final String LF = "\n";

--- a/src/test/java/com/treasure_data/td_import/integration/MessagePackFileGenerator.java
+++ b/src/test/java/com/treasure_data/td_import/integration/MessagePackFileGenerator.java
@@ -4,17 +4,19 @@ import java.io.IOException;
 import java.util.Map;
 
 import org.junit.Ignore;
-import org.msgpack.MessagePack;
-import org.msgpack.packer.Packer;
+import org.msgpack.core.MessagePack;
+import org.msgpack.core.MessagePacker;
+import org.msgpack.value.Value;
+import org.msgpack.value.ValueFactory;
 
 @Ignore
 public class MessagePackFileGenerator extends FileGenerator {
-    private Packer packer;
+    private MessagePacker packer;
 
     public MessagePackFileGenerator(String fileName, String[] header)
             throws IOException {
         super(fileName, header);
-        packer = new MessagePack().createPacker(out);
+        packer = MessagePack.newDefaultPacker(out);
     }
 
     public void writeHeader() throws IOException {
@@ -22,7 +24,11 @@ public class MessagePackFileGenerator extends FileGenerator {
     }
 
     public void write(Map<String, Object> map) throws IOException {
-        packer.write(map);
+        ValueFactory.MapBuilder b = ValueFactory.newMapBuilder();
+        for (Map.Entry<String, Object> e : map.entrySet()) {
+            b.put(ValueFactory.newString(e.getKey()), (Value) e.getValue());
+        }
+        packer.packValue(b.build());
     }
 
     @Override

--- a/src/test/java/com/treasure_data/td_import/integration/SyslogFileGenerator.java
+++ b/src/test/java/com/treasure_data/td_import/integration/SyslogFileGenerator.java
@@ -6,17 +6,17 @@ import java.util.Date;
 import java.util.Map;
 
 import org.junit.Ignore;
-import org.msgpack.type.Value;
-import org.msgpack.type.ValueFactory;
+import org.msgpack.value.Value;
+import org.msgpack.value.ValueFactory;
 
 @Ignore
 public class SyslogFileGenerator extends FileGenerator {
     private final SimpleDateFormat dateFormat = new SimpleDateFormat("MMM dd HH:mm:ss");
 
-    static Value HOST_VALUE = ValueFactory.createRawValue("host");
-    static Value IDENT_VALUE = ValueFactory.createRawValue("ident");
-    static Value MESSAGE_VALUE = ValueFactory.createRawValue("message");
-    static Value PID_VALUE = ValueFactory.createRawValue("pid");
+    static Value HOST_VALUE = ValueFactory.newString("host");
+    static Value IDENT_VALUE = ValueFactory.newString("ident");
+    static Value MESSAGE_VALUE = ValueFactory.newString("message");
+    static Value PID_VALUE = ValueFactory.newString("pid");
 
     protected static final String SPACE = " ";
     protected static final String LF = "\n";

--- a/src/test/java/com/treasure_data/td_import/integration/TrainingDataFileGenerator.java
+++ b/src/test/java/com/treasure_data/td_import/integration/TrainingDataFileGenerator.java
@@ -7,13 +7,15 @@ import java.util.Map;
 import java.util.zip.GZIPOutputStream;
 
 import org.junit.Ignore;
-import org.msgpack.MessagePack;
-import org.msgpack.packer.Packer;
+import org.msgpack.core.MessagePack;
+import org.msgpack.core.MessagePacker;
+import org.msgpack.value.Value;
+import org.msgpack.value.ValueFactory;
 
 @Ignore
 public class TrainingDataFileGenerator extends FileGenerator {
 
-    protected Packer packer;
+    protected MessagePacker packer;
 
     protected List<Object> kvs;
 
@@ -21,7 +23,7 @@ public class TrainingDataFileGenerator extends FileGenerator {
         super(fileName, header);
 
         out = new GZIPOutputStream(this.out);
-        packer = new MessagePack().createPacker(out);
+        packer = MessagePack.newDefaultPacker(out);
         this.kvs = new ArrayList<Object>();
     }
 
@@ -31,7 +33,12 @@ public class TrainingDataFileGenerator extends FileGenerator {
     }
 
     public void write(Map<String, Object> map) throws IOException {
-        packer.write(map);
+        packer.packMapHeader(map.size());
+        ValueFactory.MapBuilder b = ValueFactory.newMapBuilder();
+        for (Map.Entry<String, Object> e : map.entrySet()) {
+            b.put(ValueFactory.newString(e.getKey()), (Value) e.getValue());
+        }
+        packer.packValue(b.build());
     }
 
     @Override


### PR DESCRIPTION
This PR is just for upgrading the version of MessagePack.

However, this repository has not been maintained for more than 5 years.
Meantime, MessagePack's some API was changed.

I rerered [embulk-parser-msgpack](https://github.com/frsyuki/embulk-parser-msgpack/tree/master/src/main/java/org/embulk/parser/msgpack),  [embulk-output-td](https://github.com/treasure-data/embulk-output-td/tree/master/src/main/java/org/embulk/output/td) and [td-client-java](https://github.com/treasure-data/td-client-java/tree/master/src/main/java/com/treasuredata/client) to update code.