### PR TITLE
Add Maven GPG plugin to sign artifacts with GnuPG

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -323,4 +323,34 @@
       </plugin>
     </plugins>
   </reporting>
+
+  <profiles>
+    <profile>
+      <id>release-sign-artifacts</id>
+      <activation>
+        <property>
+          <name>performRelease</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.6</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
I got a `Missing Signature` failure while I was trying to release the artifacts to Maven on Sonatype Nexus. I can publish to **Staging Repositories** but can't **close** its repositories.
![deploy_artifacts](https://user-images.githubusercontent.com/155269/67067988-77a12400-f1b3-11e9-8242-4e6c4bc77f4a.png)

It seems we have to add `org.apache.maven.plugins.maven-gpg-plugin` to sign artifacts with GnuPG like td-client-java https://github.com/treasure-data/td-client-java/blob/777b3b42e8563ab128fcad5127d030553936da22/pom.xml#L549-L575

I confirmed the repository can be closed without any failures with this change. The release process also would success.